### PR TITLE
Empty dependency array in module declaration

### DIFF
--- a/src/scripts/placeholder.js
+++ b/src/scripts/placeholder.js
@@ -4,7 +4,7 @@
 IE 9 Full
 IE <=8 Simple (password type not supported) - Error:"Could not get the type property. This command is not supported."
 */
-angular.module('io.modernizr')
+angular.module('io.modernizr', [])
 .directive('placeholder', ['$timeout', function($timeout) {
 	return {
 		restrict: 'A',

--- a/src/scripts/reveal.icon.js
+++ b/src/scripts/reveal.icon.js
@@ -12,7 +12,7 @@ Requires: css .form-reveal
 ** refactor using ??  https://www.youtube.com/watch?v=_6ijcqI5fi8&list=PLP6DbQBkn9ymGQh2qpk9ImLHdSH5T7yw7
 */
 
-angular.module('io.modernizr')
+angular.module('io.modernizr', [])
 .directive('input', ['$compile', function($compile) {
 	return {
 		restrict: 'E',

--- a/src/scripts/reveal.text.js
+++ b/src/scripts/reveal.text.js
@@ -12,7 +12,7 @@ Requires: css .form-reveal
 ** refactor using ??  https://www.youtube.com/watch?v=_6ijcqI5fi8&list=PLP6DbQBkn9ymGQh2qpk9ImLHdSH5T7yw7
 */
 
-angular.module('io.modernizr')
+angular.module('io.modernizr', [])
 .directive('input', ['$compile', function($compile) {
 	return {
 		restrict: 'E',


### PR DESCRIPTION
Added empty dependency array to module declarations to avoid having to declare dependencies before using the module. Now, instead of this:

angular.module('io.modernizr', []);
angular.module('app', ['io.modernizr']);

you can just do this:

angular.module('app', ['io.modernizr']);
